### PR TITLE
Add prepublish build process of es2015 module 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+lib

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Regular expression for matching IP addresses (IPv4 & IPv6)",
   "main": "./lib/index.js",
   "module": "index.js",
+  "browser": "./lib/index.js",
   "license": "MIT",
   "repository": "sindresorhus/ip-regex",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "ip-regex",
   "version": "2.1.0",
   "description": "Regular expression for matching IP addresses (IPv4 & IPv6)",
+  "main": "./lib/index.js",
+  "module": "index.js",
   "license": "MIT",
   "repository": "sindresorhus/ip-regex",
   "author": {
@@ -13,9 +15,12 @@
     "node": ">=4"
   },
   "scripts": {
+    "build": "babel index.js --presets babel-preset-es2015 --out-dir lib",
+    "prepublish": "npm run build",
     "test": "xo && ava"
   },
   "files": [
+    "lib",
     "index.js"
   ],
   "keywords": [
@@ -37,6 +42,8 @@
   ],
   "devDependencies": {
     "ava": "*",
+    "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
     "xo": "*"
   },
   "xo": {


### PR DESCRIPTION
This is mainly for compatibly with `webpack` + `uglifyjs`

Currently `webpack` use `uglifyjs@2` which don't have support for ES6 modules and it will fail during production build. 