### PR TITLE
Update readme.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=8.10.0"
 	},
 	"scripts": {
 		"test": "xo && ava"

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 $ npm install ip-regex
 ```
 
-This module targets Node.js 8 or later and the latest version of Chrome, Firefox, and Safari. If you want support for older browsers, use version 2.1.0: `npm install ip-regex@2.1.0`
+This module targets Node.js 8.10.0 or later and the latest version of Chrome, Firefox, and Safari. If you want support for older browsers, use version 2.1.0: `npm install ip-regex@2.1.0`
 
 
 ## Usage


### PR DESCRIPTION
ip-regex v3.0.0 can't work in node v8.9.4 (without --harmony), because "RegExp Lookbehind Assertions" (`(?<=)`) is been used.

But this feature is shipped in **v8** 6.2, and node.js v8.10.0 upgrade v8 to this version.