### PR TITLE
Add `includeBoundaries` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const word = '[a-fA-F\\d:]';
-const b = `(?:(?<=\\s|^)(?=${word})|(?<=${word})(?=\\s|$))`;
+const b = opts => opts && opts.includeBoundaries ?
+	`(?:(?<=\\s|^)(?=${word})|(?<=${word})(?=\\s|$))` :
+	'';
 
 const v4 = '(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}';
 
@@ -21,9 +23,9 @@ const v6 = `
 
 const ip = opts => opts && opts.exact ?
 	new RegExp(`(?:^${v4}$)|(?:^${v6}$)`) :
-	new RegExp(`(?:${b}${v4}${b})|(?:${b}${v6}${b})`, 'g');
+	new RegExp(`(?:${b(opts)}${v4}${b(opts)})|(?:${b(opts)}${v6}${b(opts)})`, 'g');
 
-ip.v4 = opts => opts && opts.exact ? new RegExp(`^${v4}$`) : new RegExp(`${b}${v4}${b}`, 'g');
-ip.v6 = opts => opts && opts.exact ? new RegExp(`^${v6}$`) : new RegExp(`${b}${v6}${b}`, 'g');
+ip.v4 = opts => opts && opts.exact ? new RegExp(`^${v4}$`) : new RegExp(`${b(opts)}${v4}${b(opts)}`, 'g');
+ip.v6 = opts => opts && opts.exact ? new RegExp(`^${v6}$`) : new RegExp(`${b(opts)}${v6}${b(opts)}`, 'g');
 
 module.exports = ip;

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,14 @@ ipRegex.v6({exact: true}).test('1:2:3:4:5:6:7:8');
 
 'unicorn 192.168.0.1 cake 1:2:3:4:5:6:7:8 rainbow'.match(ipRegex());
 //=> ['192.168.0.1', '1:2:3:4:5:6:7:8']
+
+// Contains an IP address?
+ipRegex({includeBoundaries: true}).test('192.168.0.2000000000');
+//=> false
+
+// Matches an IP address?
+'192.168.0.2000000000'.match(ipRegex({includeBoundaries: true}));
+//=> null
 ```
 
 
@@ -54,6 +62,12 @@ Default: `false` *(Matches any IP address in a string)*
 
 Only match an exact string. Useful with `RegExp#test()` to check if a string is an IP address.
 
+#### options.includeBoundaries
+
+Type: `boolean`<br>
+Default: `false`
+
+Include boundaries in the RegExp. When active, `192.168.0.2000000000` will report an invalid ipv4 address. If this option is not set, the mentioned ipv4 address would report as valid (ignoring the trailing zeros).
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,8 @@ Only match an exact string. Useful with `RegExp#test()` to check if a string is 
 Type: `boolean`<br>
 Default: `false`
 
-Include boundaries in the RegExp. When active, `192.168.0.2000000000` will report an invalid ipv4 address. If this option is not set, the mentioned ipv4 address would report as valid (ignoring the trailing zeros).
+Include boundaries in the regex. When `true`, `192.168.0.2000000000` will report as an invalid IPv4 address. If this option is not set, the mentioned IPv4 address would report as valid (ignoring the trailing zeros).
+
 
 ## Related
 


### PR DESCRIPTION
Restored previous behavior:

```js
const ipRegex = require('ip-regex');

// Contains an IP address?
ipRegex().test('192.168.0.2000000000');
//=> true

// Matches an IP address
'192.168.0.2000000000'.match(ipRegex());
//=> '192.168.0.200'
```

Added `includeBoundaries` option:

```js
const ipRegex = require('ip-regex');

// Contains an IP address?
ipRegex({includeBoundaries: true}).test('192.168.0.2000000000');
//=> false

// Matches an IP address?
'192.168.0.2000000000'.match(ipRegex({includeBoundaries: true}));
//=> null
```